### PR TITLE
Shell quotes

### DIFF
--- a/l3sys-query.lua
+++ b/l3sys-query.lua
@@ -433,7 +433,7 @@ end
 -- Lua pattern, and then to do a listing.
 cmd_desc.ls = "Prints a listing based on the <args> and <options>"
 function cmd_impl.ls(arg_list)
-  if not arg_list or arg_list == "" then
+  if not arg_list or arg_list == "" or arg_list = "." then
     arg_list = "*"
   end
   -- Look for absolute paths or any trying to leave the confines of the current

--- a/l3sys-query.lua
+++ b/l3sys-query.lua
@@ -86,7 +86,7 @@ local option_list =
         short = "r",
         type  = "boolean"
       },
-    ["reverse-sort"] =
+    reverse =
       {
         cmds = {"ls"},
         desc = "Reversing sorting order",
@@ -507,7 +507,7 @@ function cmd_impl.ls(arg_list)
     end
   end
 
-  if options["reverse-sort"] then
+  if options.reverse then
     sort(s,function(a,b) return case(a) > case(b) end)
   else
     sort(s,function(a,b) return case(a) < case(b) end)

--- a/l3sys-query.lua
+++ b/l3sys-query.lua
@@ -161,8 +161,7 @@ end
 -- Remove '...' or :...: around an entire text:
 -- we need this to support restricted shell escape on Windows
 local function dequote(text)
-  if (match(text,"^'") and match(text,"'$")) or
-     (match(text,"^:") and match(text,":$")) then
+  if (match(text,"^'") and match(text,"'$")) then
     return sub(text,2,-2)
   end
   return text

--- a/l3sys-query.lua
+++ b/l3sys-query.lua
@@ -137,13 +137,20 @@ local sort   = table.sort
 -- Support functions and data
 --
 
--- Remove '...' or :...: around an entire text:
+-- Remove '...' around an entire text:
 -- we need this to support restricted shell escape on Windows
 local function dequote(text)
   if (match(text,"^'") and match(text,"'$")) then
     return sub(text,2,-2)
   end
   return text
+end
+
+
+-- A short auxiliary used whever the script bails out
+local function info_and_quit(s)
+  stderr:write("\n" .. s .. "\nTry '" .. script_name .. " --help' for more information.\n")
+  exit(1)
 end
 
 -- Convert a file glob into a pattern for use by e.g. string.gub
@@ -185,7 +192,7 @@ local function glob_to_pattern(glob,skip_convert)
       pattern = pattern .. ".*"
     elseif char == "[" then -- ]
       -- Ignored
-      print("[...] syntax not supported in globs!")
+      info_and_quit("[...] syntax not supported in globs!")
     elseif char == "\\" then
       i = i + 1
       char = sub(glob,i,i)
@@ -201,11 +208,6 @@ local function glob_to_pattern(glob,skip_convert)
   return pattern
 end
 
--- A short auxiliary used whever the script bails out
-local function more_info()
-  stderr:write("Try '" .. script_name .. " --help' for more information.\n")
-  exit(1)
-end
 
 -- Initial data for the command line parser
 local cmd = ""
@@ -298,22 +300,19 @@ local function parse_args()
         if option_list[optname].type == "boolean" then
           if optarg then
             local opt = "-" .. (match(a,"^%-%-") and "-" or "") .. opt
-            stderr:write("Value not allowed for option " .. opt .. "\n")
-            more_info()
+            info_and_quit("Value not allowed for option " .. opt)
           end
         else
           if not optarg then
             optarg = arg[i + 1]
             if not optarg then
-              stderr:write("Missing value for option " .. a .. "\n")
-              more_info()
+              info_and_quit("Missing value for option " .. a)
             end
             i = i + 1
           end
         end
       else
-        stderr:write("Unknown option " .. a .. "\n")
-        more_info()
+        info_and_quit("Unknown option " .. a)
       end
 
       -- Store the result
@@ -533,9 +532,8 @@ elseif not cmd_impl[cmd] then
   if cmd == "" then
     help()
   else
-    stderr:write(script_name .. ": '" .. cmd .. "' is not a " .. script_name ..
-      " command.\n")
-    more_info()
+    info_and_quit(script_name .. ": '" .. cmd .. "' is not a " .. script_name ..
+      " command.")
   end
   exit(1)
 end
@@ -555,9 +553,8 @@ for k,_ in pairs(options) do
       t[v] = true
     end
     if not t[cmd] then
-      stderr:write(script_name .. ": Option '" .. k .. 
-        "' does not apply to '"  .. cmd .. "'\n")
-      more_info()
+      info_and_quit(script_name .. ": Option '" .. k .. 
+        "' does not apply to '"  .. cmd .. "'")
     end
   end
 end

--- a/l3sys-query.lua
+++ b/l3sys-query.lua
@@ -48,12 +48,6 @@ local cmd_desc = {}
 
 local option_list =
   {
-    all =
-      {
-        cmds = {"ls"},
-        desc = "Include 'dot' entries in directory listing",
-        type = "boolean"
-      },
     exclude =
       {
         cmds = {"ls"},

--- a/l3sys-query.lua
+++ b/l3sys-query.lua
@@ -118,10 +118,6 @@ local option_list =
 local io     = io
 local stderr = io.stderr
 
-local kpse             = kpse
-local set_program_name = kpse.set_program_name
-local var_value        = kpse.var_value
-
 local lfs        = lfs
 local attributes = lfs.attributes
 local currentdir = lfs.currentdir
@@ -142,17 +138,6 @@ local table  = table
 local concat = table.concat
 local insert = table.insert
 local sort   = table.sort
-
---
--- Read security settings
---
-
-set_program_name("kpsewhich")
-local is_paranoid = false
-local open_mode = var_value("openin_any")
-if open_mode and open_mode ~= "a" then
-  is_paranoid = true
-end
 
 --
 -- Support functions and data
@@ -487,13 +472,11 @@ function cmd_impl.ls(arg_list)
 
   -- Build a table of entries, excluding "." and "..", and return as a string
   -- with one entry per line.
-  local is_all = options.all and not is_paranoid
   local opt = options.type
   local is_rec = options.recursive
   local function browse(path)
     for entry in dir(path) do
-      if entry ~= "." and entry ~= ".."
-        and (is_all or not match(entry,"^%.")) then
+      if entry ~= "." and entry ~= ".." and not match(entry,"^%.") then
         local full_entry = path .. "/" .. entry
         local ft = attributes(full_entry,"mode")
         if not opt or ft == attrib_map[opt] then

--- a/l3sys-query.lua
+++ b/l3sys-query.lua
@@ -433,7 +433,7 @@ end
 -- Lua pattern, and then to do a listing.
 cmd_desc.ls = "Prints a listing based on the <args> and <options>"
 function cmd_impl.ls(arg_list)
-  if not arg_list or arg_list == "" or arg_list = "." then
+  if not arg_list or arg_list == "" or arg_list == "." then
     arg_list = "*"
   end
   -- Look for absolute paths or any trying to leave the confines of the current

--- a/l3sys-query.sty
+++ b/l3sys-query.sty
@@ -6,7 +6,7 @@
 
 % Defines:
 
-% \QueryPWD {<result>}
+% \QueryWorkingDirectory {<result>}
 % defines the command passed in as #1 to be the current working directory
 
 % \QueryFiles[<options>]{<args>}{function}
@@ -20,8 +20,8 @@
 
 \ExplSyntaxOn
 
-\NewDocumentCommand\QueryPWD {m} {
-  \sys_get_query:nnnN {pwd} {} {} #1
+\NewDocumentCommand\QueryWorkingDirectory {m} {
+  \sys_get_query:nN {pwd} #1
 }
 
 \NewDocumentCommand\QueryFiles {} {

--- a/l3sys-query.sty
+++ b/l3sys-query.sty
@@ -1,0 +1,72 @@
+
+\ProvidesPackage{l3sys-query}[2024-03-08 v0.01 LaTeX2e interface for l3sys file queries]
+
+% Copyright 2024  The LaTeX Project
+% License: LPPL 1.3c
+
+% Defines:
+
+% \QueryPWD {<result>}
+% defines the command passed in as #1 to be the current working directory
+
+% \QueryFiles[<options>]{<args>}{function}
+% produces a file list based on args and the options then applies function to each one.
+% function should be a macro body which will be passed the file path as  #1
+% on each iteration.
+% For options and details see l3sys.dtx
+
+\ExplSyntaxOn
+
+\NewDocumentCommand\QueryPWD {m} {
+  \sys_get_query:nnnN {pwd} {} {} #1
+}
+
+
+\NewDocumentCommand\QueryFiles {} {
+  \group_begin:
+    \char_set_catcode_other:N \~
+    \char_set_catcode_other:N \%
+    \QueryFiles_inner
+ }
+\NewDocumentCommand\QueryFiles_inner {O{}mm}{
+  \group_end:
+  \tl_set:Nn\l_tmpa_tl{}
+  \keys_set:nn{QueryFiles}{#1}
+  \exp_args:NnV\sys_split_query:nnnN {ls} \l_tmpa_tl {#2} \l_tmpa_seq
+  \seq_map_inline:Nn\l_tmpa_seq{#3}
+}
+
+\keys_define:nn {QueryFiles} {
+recursive .code:n  =\tl_put_right:Nn \l_tmpa_tl {--recursive ~ } ,
+recursive .value_forbidden:n = true ,
+
+all .code:n  =\tl_put_right:Nn \l_tmpa_tl {--all ~ } ,
+all .value_forbidden:n = true ,
+
+ignore-case .code:n  =\tl_put_right:Nn \l_tmpa_tl {--ignore-case ~ } ,
+ignore-case .value_forbidden:n = true ,
+
+reverse-sort .code:n  =\tl_put_right:Nn \l_tmpa_tl {--reverse-sort ~ } ,
+reverse-sort .value_forbidden:n = true ,
+
+exclude .code:n  =\tl_put_right:Ne \l_tmpa_tl {
+  --exclude ~
+  \sys_if_shell_restricted:TF: :'
+  \exp_not:n{#1}
+  \sys_if_shell_restricted:TF: :'
+  ~ } ,
+exclude .value_required:n = true ,
+
+type .choices:nn = {d,f}
+                   {\tl_put_right:Nn \l_tmpa_tl {--type ~ #1 ~ }} ,
+sort .choices:nn = {date,name}
+{\tl_put_right:Nn \l_tmpa_tl {--sort ~ #1 ~ }} ,
+
+
+pattern .code:n  =\tl_put_right:Nn \l_tmpa_tl {--pattern ~ } ,
+pattern .value_forbidden:n = true ,
+
+}
+
+
+\ExplSyntaxOff

--- a/l3sys-query.sty
+++ b/l3sys-query.sty
@@ -10,10 +10,13 @@
 % defines the command passed in as #1 to be the current working directory
 
 % \QueryFiles[<options>]{<args>}{function}
+% \QueryFilesTF[<options>]{<args>}{function}{<Pre list code>}{<empty list code>}
 % produces a file list based on args and the options then applies function to each one.
 % function should be a macro body which will be passed the file path as  #1
 % on each iteration.
 % For options and details see l3sys.dtx
+% The TF version executes the T (<Pre list code>) argument before iterating over the list
+% and the F (<empty list code>) argument if the list is empty
 
 \ExplSyntaxOn
 
@@ -21,20 +24,42 @@
   \sys_get_query:nnnN {pwd} {} {} #1
 }
 
-
 \NewDocumentCommand\QueryFiles {} {
   \group_begin:
     \char_set_catcode_other:N \~
     \char_set_catcode_other:N \%
     \QueryFiles_inner
  }
-\NewDocumentCommand\QueryFiles_inner {O{}mm}{
+\NewDocumentCommand\QueryFiles_inner {O{}m}{
   \group_end:
   \tl_set:Nn\l_tmpa_tl{}
   \keys_set:nn{QueryFiles}{#1}
   \exp_args:NnV\sys_split_query:nnnN {ls} \l_tmpa_tl {#2} \l_tmpa_seq
-  \seq_map_inline:Nn\l_tmpa_seq{#3}
+  \seq_map_inline:Nn\l_tmpa_seq
 }
+
+% duplicates rather than shares code so as to read the function and TF arguments
+% with normal catcode regime. (This could probably be optimised)
+
+\NewDocumentCommand\QueryFilesTF {} {
+  \group_begin:
+    \char_set_catcode_other:N \~
+    \char_set_catcode_other:N \%
+    \QueryFilesTF_inner
+ }
+\NewDocumentCommand\QueryFilesTF_inner {O{}m}{
+  \group_end:
+  \tl_set:Nn\l_tmpa_tl{}
+  \keys_set:nn{QueryFiles}{#1}
+  \exp_args:NnV\sys_split_query:nnnN {ls} \l_tmpa_tl {#2} \l_tmpa_seq
+  \seq_if_empty:NTF \l_tmpa_seq \use_iii:nnn \__queryfiles_aux:nnn
+}
+
+
+\cs_new:Npn  \__queryfiles_aux:nnn #1#2#3 {
+    #2
+    \seq_map_inline:Nn\l_tmpa_seq {#1}
+ }
 
 \keys_define:nn {QueryFiles} {
 recursive .code:n  =\tl_put_right:Nn \l_tmpa_tl {--recursive ~ } ,

--- a/l3sys-query.sty
+++ b/l3sys-query.sty
@@ -65,9 +65,6 @@
 recursive .code:n  =\tl_put_right:Nn \l_tmpa_tl {--recursive ~ } ,
 recursive .value_forbidden:n = true ,
 
-all .code:n  =\tl_put_right:Nn \l_tmpa_tl {--all ~ } ,
-all .value_forbidden:n = true ,
-
 ignore-case .code:n  =\tl_put_right:Nn \l_tmpa_tl {--ignore-case ~ } ,
 ignore-case .value_forbidden:n = true ,
 

--- a/l3sys-query.sty
+++ b/l3sys-query.sty
@@ -51,9 +51,9 @@ reverse-sort .value_forbidden:n = true ,
 
 exclude .code:n  =\tl_put_right:Ne \l_tmpa_tl {
   --exclude ~
-  \sys_if_shell_restricted:TF: :'
+  \sys_if_shell_restricted:F'
   \exp_not:n{#1}
-  \sys_if_shell_restricted:TF: :'
+  \sys_if_shell_restricted:F'
   ~ } ,
 exclude .value_required:n = true ,
 

--- a/l3sys-query.sty
+++ b/l3sys-query.sty
@@ -71,8 +71,8 @@ all .value_forbidden:n = true ,
 ignore-case .code:n  =\tl_put_right:Nn \l_tmpa_tl {--ignore-case ~ } ,
 ignore-case .value_forbidden:n = true ,
 
-reverse-sort .code:n  =\tl_put_right:Nn \l_tmpa_tl {--reverse-sort ~ } ,
-reverse-sort .value_forbidden:n = true ,
+reverse .code:n  =\tl_put_right:Nn \l_tmpa_tl {--reverse ~ } ,
+reverse .value_forbidden:n = true ,
 
 exclude .code:n  =\tl_put_right:Ne \l_tmpa_tl {
   --exclude ~

--- a/l3sys-query.tex
+++ b/l3sys-query.tex
@@ -120,7 +120,10 @@ The action of these options on the appropriate \meta{cmd(s)} is detailed below.
 Lists the contents of one or more directories, in a manner somewhat reminiscent
 of the Unix command |ls| or the Windows command |dir|. The exact nature of the
 output will depend on the \meta{args}, if given, along with the prevailing
-options.
+options. Note that the options names are inspired by ideas from the Unix
+commands |ls| and |find| as well as the Windows command |dir|: they therefore do
+not map directly to those of any one of the command line tools that they
+somewhat mirror.
 
 When no \meta{args} are given, all entries in the current directory will be
 listed, one per line in the output. This will include both files and

--- a/l3sys-query.tex
+++ b/l3sys-query.tex
@@ -157,22 +157,6 @@ obtained using
   l3sys-query ls --pattern '^.*%.png$'
 \end{verbatim}
 
-Since \texttt{l3sys-query} is intended primarily for use with restricted shell
-escape calls from \TeX{} processes, handling of spaces is unusual. It is not
-possible to quote spaces in such a call, so for example whilst
-\begin{verbatim}
-  l3sys-query ls "'foo *'"
-\end{verbatim}
-does work from the command prompt to find all files with names starting
-\verb*|foo |, it would not work \emph{via} restricted shell escape. To
-circumvent this, \texttt{l3sys-query} will collect all command line arguments
-after any \meta{options}, and combine these as a space-separated \meta{args},
-for example allowing
-\begin{verbatim}
-  l3sys-query ls 'foo *'
-\end{verbatim}
-to work.
-
 The results returned by |ls| can be sorted using the |--sort| option. This can
 be set to |none| (use the order from the file system: the default), |name| (sort
 by file name) or |date| (sort by date last modified). The sorting order can be
@@ -199,6 +183,27 @@ main file, assuming a command such as
   pdflatex main.tex
 \end{verbatim}
 The \texttt{pwd} command is unaffected by any options.
+
+\section{Spaces in arguments}
+
+Since \texttt{l3sys-query} is intended primarily for use with restricted shell
+escape calls from \TeX{} processes, handling of spaces is unusual. It is not
+possible to quote spaces in such a call, so for example whilst
+\begin{verbatim}
+  l3sys-query ls "foo *"
+\end{verbatim}
+does work from the command prompt to find all files with names starting
+\verb*|foo |, it would not work \emph{via} restricted shell escape. To
+circumvent this, \texttt{l3sys-query} will collect all command line arguments
+after any \meta{options}, and combine these as a space-separated \meta{args},
+for example allowing
+\begin{verbatim}
+  l3sys-query ls foo '*'
+\end{verbatim}
+to achieve the same result as the first example. The result is that the
+\meta{args} will only every be interpreted by \texttt{l3sys-query} as a single
+argument. It also means that spaces cannot be used at the start or end of the
+argument, nor can multiple spaces appear between non-space arguments.
 
 \section{Wildcard expansion handling\label{sec:wildcard}}
 

--- a/l3sys-query.tex
+++ b/l3sys-query.tex
@@ -101,7 +101,6 @@ use~|/|, irrespective of the platform in use.
 
 As well as these targets, the script recognizes the options
 \begin{itemize}
-  \item |--all| Include \enquote{dot} entries in directory listings
   \item |--exclude| Specification for directory entries to exclude
   \item |--ignore-case| Ignores case when sorting directory listings
   \item |--pattern| (|-p|) Treat the \meta{args} as Lua patterns rather
@@ -148,9 +147,10 @@ option, which should be given with a \meta{xarg}, for example
   l3sys-query ls --exclude '*.bak' 'graphics/*'
 \end{verbatim}
 Directory entries starting |.| are traditionally hidden on Linux and macOS
-systems: these \enquote{dot} entries are excluded unless the |--all| option is
-set. Note that this will skip hidden directories entirely when used with the
-|--recursive| option.
+systems: these \enquote{dot} entries are excluded from the output of
+\texttt{l3sys-query}. The entries |.| and |..| for the current and parent
+directory are also excluded from the results returned by \texttt{l3sys-query} as
+they can always be assumed.
 
 For more complex matching, the \meta{args} can be treated as a Lua pattern using
 the |--pattern| (|-p|) option; this also applies to the \meta{xarg} argument to
@@ -171,7 +171,8 @@ option. This takes a string argument, one of |d| (directory) or |f| (file).
 
 As standard, only the path specified as part of the \meta{args} is queried.
 However, if the |--recursive| (|-r|) option is set, the query is applied within
-all subdirectories.
+all subdirectories. Subdirectories starting with~|.| (macOS and Linux hidden)
+are excluded from recursion.
 
 For security reasons, only paths within the current working directory can be
 queried, this for example |graphics/*.png| will list all |png| files in the

--- a/l3sys-query.tex
+++ b/l3sys-query.tex
@@ -206,8 +206,6 @@ The handling of wildcards needs some further comment for those using
 \texttt{l3sys-query} from the command line: the \pkg{expl3} interface described
 in Section~\ref{sec:expl3} handles this aspect automatically for the user.
 
-\subsection{Shell use}
-
 On macOS and Linux, the shell normally expands globs, which include the
 wildcards |*| and |?|, before passing arguments to the appropriate command. This
 can be suppressed by surrounding the argument with |'| characters, hence the
@@ -218,38 +216,19 @@ formulation
 earlier.
 
 On Windows, the shell does no expansion, and thus arguments are passed as-is to
-the relevant command. However, in the \TeX{}~Live implementation of
-\texttt{texlua}, the script interpreter expands |*| and |?| \emph{before} they
-are made available to the script itself. This can only be suppressed by
-including one or more characters that prevent a match: this causes the
-\emph{entire} argument to be passed to the script, including whatever
-\enquote{extra} characters are used. Importantly, |'| has no special meaning
-here.
-
-To allow quoting of wildcards from the shell in a platform-neutral manner,
-\texttt{l3sys-query} will strip exactly one set of |'| characters around
-each argument before further processing.
-
-\subsection{Calls \emph{via} restricted shell escape}
+the relevant command. As such, |'| has no special meaning here. However, to
+allow quoting of wildcards from the shell in a platform-neutral manner,
+\texttt{l3sys-query} will strip exactly one set of |'| characters around each
+argument before further processing.
 
 Restricted shell escape prevents shell expansion of wildcards entirely, but
-also strips out all |'| characters from arguments. Thus on macOS and
-Linux, a \TeX{} call such as
+also strips out all |'| characters from arguments. Thus a \TeX{} call such as
 \begin{verbatim}
   \input|"l3sys-query ls '*.png'"
 \end{verbatim}
 will work as it is converted to one without the |'| characters (the surrounding
 |"| are needed to allow space-separated arguments to be passed as a whole to
 |\input|).
-
-On Windows, the rules of restricted shell escape mean that |'| cannot be
-used here to prevent expansion of |*| and |?|. Rather, the character |:|
-should be used: this is reserved on Windows in any case. Thus one would use
-\begin{verbatim}
-  \input|"l3sys-query ls :*.png:"
-\end{verbatim}
-on Windows; \texttt{l3sys-query} and strips out exactly one set of surrounding
-|:| characters.
 
 \section{The \LaTeX{} interface\label{sec:expl3}}
 

--- a/l3sys-query.tex
+++ b/l3sys-query.tex
@@ -107,7 +107,7 @@ As well as these targets, the script recognizes the options
     than converting from wildcards
   \item |--recursive| (|-r|) Enables recursive searching during directory
     listings
-  \item |--reverse-sort| Causes sorting to go from highest to lowest rather
+  \item |--reverse| Causes sorting to go from highest to lowest rather
     than lowest to highest
   \item |--sort| Sets the method used to sort entries returned by |ls|
   \item |--type| Selects the type of entry returned by |ls|
@@ -163,8 +163,8 @@ obtained using
 The results returned by |ls| can be sorted using the |--sort| option. This can
 be set to |none| (use the order from the file system: the default), |name| (sort
 by file name) or |date| (sort by date last modified). The sorting order can be
-reversed using |--reverse-sort|. Sorting normally takes account of case: this
-can be suppressed with the |--ignore-case| option.
+reversed using |--reverse|. Sorting normally takes account of case: this can be
+suppressed with the |--ignore-case| option.
 
 The listing can be filtered based on the type of entry using the |--type|
 option. This takes a string argument, one of |d| (directory) or |f| (file).

--- a/l3sys-query.tex
+++ b/l3sys-query.tex
@@ -230,21 +230,28 @@ allow quoting of wildcards from the shell in a platform-neutral manner,
 \texttt{l3sys-query} will strip exactly one set of |'| characters around each
 argument before further processing.
 
-Restricted shell escape prevents shell expansion of wildcards entirely, but
-also strips out all |'| characters from arguments. Thus a \TeX{} call such as
+Restricted shell escape prevents shell expansion of wildcards entirely. On
+non-Windows systems, it does this by replacing all \verb|"| by |'| and ensuring
+that each argument is |'| quoted to ensure further expansion.
+Thus a \TeX{} call such as
 \begin{verbatim}
   \input|"l3sys-query ls '*.png'"
 \end{verbatim}
-will work as it is converted to one without the |'| characters (the surrounding
-|"| are needed to allow space-separated arguments to be passed as a whole to
-|\input|).
+will work if |--shell-escape| is used as the argument is passed directly to the shell, but
+in restricted shell escape will give an error such as:
+\begin{verbatim}
+! I can't find file `"|l3sys-query ls '*.png'"'.
+\end{verbatim}
+The \LaTeX\ interfaces described below adust the quoting used depending on the |shell-escape| status.
 
 \section{The \LaTeX{} interface\label{sec:expl3}}
 
 Using \texttt{l3sys-query} is not tied to access \emph{via} \pkg{expl3}, but
 this is the preferred approach for the \LaTeX{} Team. Details of how to use
 \texttt{l3sys-query} as an \pkg{expl3} programmer will covered in
-\texttt{interface3.pdf} once the macro code is finalised.
+\texttt{interface3.pdf} once the macro code is finalised. A document level interface
+will also be provided via a \pkg{l3sys-query} package which is based on the \pkg{expl3}
+interface and will be described here.
 
 \end{documentation}
 

--- a/test-2e-01.tex
+++ b/test-2e-01.tex
@@ -1,7 +1,8 @@
 \documentclass{article}
 \usepackage{l3sys-query}
 
-\errorcontextlines888
+
+
 \QueryPWD \thisdir
 
 \typeout{PWD: \thisdir}
@@ -17,6 +18,11 @@
 
 
 \QueryFiles[pattern]{^%d.*.tex}{\typeout{E: #1}}
+
+\QueryFilesTF{t*.*}{\typeout{TFA: #1}}{\typeout{TFA files:}}{\typeout{TFA empty file list}}
+
+\QueryFilesTF{wibble*.*}{\typeout{TFB: #1}}{\typeout{TFB files:}}{\typeout{TFB empty file list}}
+
 
 \stop
 

--- a/test-2e-01.tex
+++ b/test-2e-01.tex
@@ -11,14 +11,17 @@
 \QueryFiles{*.tex}{\typeout{A: #1}}
 
 \QueryFiles[recursive,type=d]{}{\typeout{B: #1}}% . ought to work
-\QueryFiles[recursive,]{.}{\typeout{BB: #1}}% . ought to work
 
-\QueryFiles[sort=date]{*.tex}{\typeout{C: #1}}
+\QueryFiles[type=f]{}{\typeout{C_: #1}}% default
+\QueryFiles[type=f]{*}{\typeout{C*: #1}}% * same as {}
+\QueryFiles[type=f]{.}{\typeout{C.: #1}}% . same as {}
 
-\QueryFiles[pattern]{^[0-9].*.tex}{\typeout{D: #1}}
+\QueryFiles[sort=date]{*.tex}{\typeout{D: #1}}
+
+\QueryFiles[pattern]{^[0-9].*.tex}{\typeout{E: #1}}
 
 
-\QueryFiles[pattern]{^%d.*.tex}{\typeout{E: #1}}
+\QueryFiles[pattern]{^%d.*.tex}{\typeout{F: #1}}
 
 \QueryFilesTF{t*.*}{\typeout{TFA: #1}}{\typeout{TFA files:}}{\typeout{TFA empty file list}}
 

--- a/test-2e-01.tex
+++ b/test-2e-01.tex
@@ -3,9 +3,10 @@
 
 
 
-\QueryPWD \thisdir
+\QueryWorkingDirectory  \thisdir
 
 \typeout{PWD: \thisdir}
+
 
 \QueryFiles{*.tex}{\typeout{A: #1}}
 

--- a/test-2e-01.tex
+++ b/test-2e-01.tex
@@ -1,0 +1,22 @@
+\documentclass{article}
+\usepackage{l3sys-query}
+
+\errorcontextlines888
+\QueryPWD \thisdir
+
+\typeout{PWD: \thisdir}
+
+\QueryFiles{*.tex}{\typeout{A: #1}}
+
+\QueryFiles[recursive,type=d]{}{\typeout{B: #1}}% . ought to work
+\QueryFiles[recursive,]{.}{\typeout{BB: #1}}% . ought to work
+
+\QueryFiles[sort=date]{*.tex}{\typeout{C: #1}}
+
+\QueryFiles[pattern]{^[0-9].*.tex}{\typeout{D: #1}}
+
+
+\QueryFiles[pattern]{^%d.*.tex}{\typeout{E: #1}}
+
+\stop
+


### PR DESCRIPTION
the example given actually produced an error on non windows machines as the `'` in the argument conflict with the ones web2c adds.

This re-wrods the example and also in the final section gives a forward reference to a document level interface (which I think will need to be documented in this document as this will be the default result of  `texdoc l3sys-query` )