### PR TITLE
Leave command invocation only in SYNOPSIS section

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ Changelog](https://keepachangelog.com/en/1.0.0/), this project uses date-based
 
 ## [Unreleased]
 
+### Changed
+- Improvement to man file, `SYNOPSIS` section
+
 ## [2024-04-03]
 
 ### Changed

--- a/build.lua
+++ b/build.lua
@@ -22,7 +22,7 @@ function  docinit_hook()
   insert(man_t,'.TH ' .. string.upper(module) .. ' 1 "'
     .. readme:sub(date_start,date_end) .. '" "LaTeX"\n')
   insert(man_t,(".SH NAME\n" .. module .. "\n"))
-  insert(man_t,(".SH SYNOPSIS\n Usage " .. module .. " <cmd> [<options>] [<args>]\n"))
+  insert(man_t,(".SH SYNOPSIS\n" .. module .. " <cmd> [<options>] [<args>]\n"))
   insert(man_t,".SH DESCRIPTION")
 
   local _,desc_start = find(readme,"## Overview")


### PR DESCRIPTION
This also removes the leading space before "Usage" in SYNOPSIS.

Before
```
NAME
       l3sys-query


SYNOPSIS
        Usage l3sys-query <cmd> [<options>] [<args>]
//     ^ notice the leading space here
```

After
```
NAME
       l3sys-query


SYNOPSIS
       l3sys-query <cmd> [<options>] [<args>]
```